### PR TITLE
Fix relative path for schema xml file

### DIFF
--- a/ui/gtkui/gs_schema_install.sh
+++ b/ui/gtkui/gs_schema_install.sh
@@ -36,11 +36,13 @@ for COMMAND in $COMMANDS; do
     i=$(( $i + 1 ))
 done
 
+SCRIPT_DIR=$(dirname "$0")
+
 echo "Installing gsettings schema to prefix ${PREFIX}"
 
 # Copy and compile schema
 echo "Copying and compiling schema..."
 install -d ${PREFIX}/share/glib-2.0/schemas
-install -m 644 gsettings/org.d2r2.gorsync.gschema.xml ${PREFIX}/share/glib-2.0/schemas/
+install -m 644 ${SCRIPT_DIR}/gsettings/org.d2r2.gorsync.gschema.xml ${PREFIX}/share/glib-2.0/schemas/
 glib-compile-schemas ${PREFIX}/share/glib-2.0/schemas/
 


### PR DESCRIPTION
Changed relative path for org.d2r2.gorsync.gschema.xml
file to be relative to the script directory instead
of the working directory, so that it can be resolved
regardless of which directory the script is executed.

Fixes #2 